### PR TITLE
quote generated prereq version

### DIFF
--- a/lib/ExtUtils/ModuleMaker/StandardText.pm
+++ b/lib/ExtUtils/ModuleMaker/StandardText.pm
@@ -343,7 +343,7 @@ WriteMakefile(
     AUTHOR       => '%s (%s)',
     ABSTRACT     => '%s',
     PREREQ_PM    => {
-                     'Test::Simple' => 0.44,
+                     'Test::Simple' => '0.44',
                     },
 );
 ~;


### PR DESCRIPTION
Quote the version in the generated prereqs section, as leaving versions unquoted sets a bad example. Versions should be treated as strings until version.pm parses them, to avoid inaccuracies resulting from treating them as numbers. I also recommend quoting the $VERSION of each module in this dist and the prereq versions in Makefile.PL.