### PR TITLE
use VERSION method for EUMM version comparisons in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,8 +1,6 @@
 use ExtUtils::MakeMaker;
 require 5.006;
 
-my $mm_ver = ExtUtils::MakeMaker->VERSION;
-
 WriteMakefile(
     NAME         => 'ExtUtils::ModuleMaker',
     VERSION_FROM => 'lib/ExtUtils/ModuleMaker.pm',
@@ -16,13 +14,13 @@ WriteMakefile(
         ($^O =~ /Win32/ ? (Win32 => 0) : ()),
         File::Save::Home => 0.03,
     },
-    ( $mm_ver < 6.63_03 ? 'BUILD_REQUIRES' : 'TEST_REQUIRES' ) => {
+    ( eval { ExtUtils::MakeMaker->VERSION('6.63_03'); 1 } ? 'TEST_REQUIRES' : 'BUILD_REQUIRES' ) => {
                      'IO::Capture' => 0,
                      'Test::More' => 0.44,
                     },
     LICENSE      => "perl",
     test        => { TESTS => join q{ }, map {glob} qw( t/*.t t/*/*.t ) },
-    ($mm_ver < 6.46 ? () : (META_MERGE => {
+    (eval { ExtUtils::MakeMaker->VERSION('6.46'); 1 } ? (META_MERGE => {
         'meta-spec' => { version => 2 },
         dynamic_config => 1,
         resources => {
@@ -36,6 +34,6 @@ WriteMakefile(
                 web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=ExtUtils-ModuleMaker',
             },
         },
-    })),
+    }) : ()),
 );
 


### PR DESCRIPTION
The proper way to check for a particular version of a module is by calling the VERSION method on a version to test so that version.pm can make the comparison, rather than directly using numeric comparisons.